### PR TITLE
Add Intellij IDE excludes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ composer.phar
 # Since this is bound for packagist, do not commit vendor or lockfile
 vendor/
 composer.lock
+
+# Intellij
+.idea/
+*.iml
+*.ipr
+*.iws
+*.uml
+out/


### PR DESCRIPTION
This PR adds the following Intellij IDE excludes to the .gitignore.

```
# Intellij IDE
.idea/
*.iml
*.ipr
*.iws
*.uml
out/
```