### PR TITLE
Added CFG variable to allow jonPostel check to work

### DIFF
--- a/src/Util/LTI13.php
+++ b/src/Util/LTI13.php
@@ -225,6 +225,7 @@ class LTI13 {
      * @param array $failures A string array of failures (pass by reference)
      */
     public static function jonPostel($body, &$failures) {
+		global $CFG;
         if ( isset($CFG->jon_postel) ) return; // We are on Jon Postel mode
 
         // Sanity checks


### PR DESCRIPTION
Minor fix to allow jonPostel check to work.  Ran into this because I'm trying to create a tool placement for an Admin tool in Bb Learn, and tsugi is throwing errors because there is no resource_link_id.