### PR TITLE
Configurable forwarded IPs

### DIFF
--- a/src/Config/ConfigInfo.php
+++ b/src/Config/ConfigInfo.php
@@ -730,6 +730,23 @@ class ConfigInfo {
     public $websocket_url = false;
     public $websocket_proxyport = false;
 
+    /**
+     * If the web server is NOT behind a reverse proxy, you may optionally wish
+     * to ignore forwarded IP headers such as x-forwarded-for and variations by
+     * setting this to false. This will help to preserve authenticity of IPs by
+     * only trusting IP addresses directly seen by the server.
+     *
+     * Never set this to false if you ARE behind a reverse proxy, otherwise all
+     * requests will appear to originate from the same IP address (the proxy).
+     *
+     * If behind a reverse proxy, set to `true`:
+     *     $CFG->trust_forwarded_ip = true; // (default)
+     *
+     * If not using a reverse proxy, set to `false`:
+     *     $CFG->trust_forwarded_ip = false;
+     */
+    public $trust_forwarded_ip = true;
+
     /*
      * This is the internal version of the datbase.   This is an internal
      * value and set in setup.php and read in migrate.php - you should not

--- a/src/Util/Net.php
+++ b/src/Util/Net.php
@@ -476,6 +476,8 @@ class Net {
      */
     public static function getIP() {
 
+        global $CFG;
+
         //Just get the headers if we can or else use the SERVER global
         if ( function_exists( 'apache_request_headers' ) ) {
             $rawheaders = apache_request_headers();
@@ -496,6 +498,11 @@ class Net {
         $filter_option = 0;
 
         $the_ip = false;
+
+        // When not behind proxy, trust IP from web server over headers
+        if ( $CFG->trust_forwarded_ip === false && array_key_exists( 'REMOTE_ADDR', $_SERVER ) ) {
+            $the_ip = filter_var( $_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP, $filter_option );
+        }
 
         // Check Cloudflare headers
         if ( $the_ip === false && array_key_exists( 'http_cf_connecting_ip', $headers ) ) {


### PR DESCRIPTION
Provide option to ignore forwarded IP headers for those not running Tsugi behind a reverse proxy. Defaults to trusting headers, following the principle of least surprise, and not altering default behaviour.