### PR TITLE
Added user agent to LTI calls

### DIFF
--- a/src/Util/LTI13.php
+++ b/src/Util/LTI13.php
@@ -480,6 +480,8 @@ class LTI13 {
         if ( is_array($debug_log) ) $debug_log[] = $headers;
         if ( is_array($debug_log) ) $debug_log[] = $grade_call;
 
+        self::setUserAgentCurl($ch); // Set the User-Agent header
+
         $line_item = curl_exec($ch);
         if ( $line_item === false ) return self::handle_curl_error($ch, $debug_log);
 
@@ -536,6 +538,8 @@ class LTI13 {
 
             if ( is_array($debug_log) ) $debug_log[] = $membership_url;
             if ( is_array($debug_log) ) $debug_log[] = $headers;
+
+            self::setUserAgentCurl($ch); // Set the User-Agent header
 
             $membership = curl_exec($ch);
             if ( $membership === false ) return self::handle_curl_error($ch, $debug_log);
@@ -637,6 +641,8 @@ class LTI13 {
             if ( is_array($debug_log) ) $debug_log[] = $context_groups_url;
             if ( is_array($debug_log) ) $debug_log[] = $headers;
 
+            self::setUserAgentCurl($ch); // Set the User-Agent header
+
             $lti_groups = curl_exec($ch);
             if ( $lti_groups === false ) return self::handle_curl_error($ch, $debug_log);
 
@@ -727,6 +733,8 @@ class LTI13 {
         if (is_array($debug_log) ) $debug_log[] = 'Line Items URL: '.$lineitems_url;
         if (is_array($debug_log) ) $debug_log[] = $headers;
 
+        self::setUserAgentCurl($ch); // Set the User-Agent header
+
         $lineitems = curl_exec($ch);
         if ( $lineitems === false ) return self::handle_curl_error($ch, $debug_log);
 
@@ -778,6 +786,8 @@ class LTI13 {
 
         if (is_array($debug_log) ) $debug_log[] = 'Line Items URL: '.$lineitem_url;
         if (is_array($debug_log) ) $debug_log[] = $headers;
+
+        self::setUserAgentCurl($ch); // Set the User-Agent header
 
         $lineitem = curl_exec($ch);
         if ( $lineitem === false ) return self::handle_curl_error($ch, $debug_log);
@@ -835,6 +845,8 @@ class LTI13 {
 
         if (is_array($debug_log) ) $debug_log[] = 'Line Items URL: '.$actual_url;
         if (is_array($debug_log) ) $debug_log[] = $headers;
+
+        self::setUserAgentCurl($ch); // Set the User-Agent header
 
         $results = curl_exec($ch);
         if ( $results === false ) return self::handle_curl_error($ch, $debug_log);
@@ -896,6 +908,8 @@ class LTI13 {
 
         if (is_array($debug_log) ) $debug_log[] = 'Line Item URL: '.$lineitem_url;
         if (is_array($debug_log) ) $debug_log[] = $headers;
+
+        self::setUserAgentCurl($ch); // Set the User-Agent header
 
         $response = curl_exec($ch);
         if ( $response === false ) return self::handle_curl_error($ch, $debug_log);
@@ -969,6 +983,8 @@ class LTI13 {
         if (is_array($debug_log) ) $debug_log[] = 'Line Items URL: '.$lineitems_url;
         if (is_array($debug_log) ) $debug_log[] = $headers;
 
+        self::setUserAgentCurl($ch); // Set the User-Agent header
+
         $line_item = curl_exec($ch);
         if ( $line_item === false ) return self::handle_curl_error($ch, $debug_log);
 
@@ -1037,6 +1053,8 @@ class LTI13 {
 
         if (is_array($debug_log) ) $debug_log[] = 'Line Item URL: '.$lineitem_url;
         if (is_array($debug_log) ) $debug_log[] = $headers;
+
+        self::setUserAgentCurl($ch); // Set the User-Agent header
 
         $line_item = curl_exec($ch);
         if ( $line_item === false ) return self::handle_curl_error($ch, $debug_log);
@@ -1120,6 +1138,8 @@ class LTI13 {
         if ( is_array($debug_log) ) $debug_log[] = $auth_request;
         if ( is_array($debug_log) ) $debug_log[] = "Post Data:";
         if ( is_array($debug_log) ) $debug_log[] = $query;
+
+        self::setUserAgentCurl($ch); // Set the User-Agent header
 
         $token_str = curl_exec($ch);
         if ( $token_str === false ) {
@@ -1478,4 +1498,19 @@ class LTI13 {
         return null;
     }
 
+    public static function setUserAgentCurl($ch)
+    {
+        global $CFG;
+
+        // Construct a robust default User-Agent
+        $default_agent = 'Tsugi/' .
+            (defined('TSUGI_VERSION') ? TSUGI_VERSION : 'dev') .
+            ' (' . (isset($CFG->wwwroot) ? $CFG->wwwroot : 'https://www.tsugi.org') . ')' .
+            ' PHP/' . phpversion();
+
+        // Allow overrides via extension mechanism
+        $user_agent = $CFG->getExtension('user_agent', $default_agent);
+
+        curl_setopt($ch, CURLOPT_USERAGENT, $user_agent);
+    }
 }


### PR DESCRIPTION
With the upcoming changes to Canvas, the Net.php library had been updated to include setting the user agent header for cURL, but we found LTI13.php was not.  Some of our tools use NRPS with Canvas, so we need these calls to be compliant as well.